### PR TITLE
Fix main window not filling full screen width (#222)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,16 +44,3 @@ Proceed.
 
 
 Run timestamp: 2026-02-01T18:57:36.003Z
-
----
-
-Issue to solve: https://github.com/netkeep80/isocubic/issues/222
-Your prepared branch: issue-222-b2f10cdb49fc
-Your prepared working directory: /tmp/gh-issue-solver-1769974522843
-Your forked repository: konard/netkeep80-isocubic
-Original repository (upstream): netkeep80/isocubic
-
-Proceed.
-
-
-Run timestamp: 2026-02-01T19:35:28.507Z


### PR DESCRIPTION
## Summary

- Fixed the main window being less than half the screen width horizontally instead of filling the entire screen
- **Root cause**: `body` in `src/index.css` had `display: flex` with `place-items: center`, which centered the `#root` div horizontally and caused it to shrink to its content's intrinsic width
- **Fix**: Removed `display: flex` and `place-items: center` from `body`, added explicit `width: 100%` and `min-height: 100vh` to `#root`

## Test plan

- [x] All 3383 existing tests pass (109 test files)
- [x] Type checking passes (`vue-tsc --noEmit`)
- [x] Lint passes (0 errors)
- [ ] Visual verification: main window should now occupy the full screen width on desktop

Fixes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)