### PR TITLE
Fix UnifiedEditor prop binding in App.vue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/netkeep80/isocubic/issues/266
-Your prepared branch: issue-266-1aeb1ec4d873
-Your prepared working directory: /tmp/gh-issue-solver-1770392248111
-Your forked repository: konard/netkeep80-isocubic
-Original repository (upstream): netkeep80/isocubic
-
-Proceed.


### PR DESCRIPTION
## Summary

- **Root Cause**: In `App.vue`, the `UnifiedEditor` component was receiving `:cube="currentCube"` instead of `:current-cube="currentCube"`. Since the component defines its prop as `currentCube` (Vue kebab-case: `current-cube`), the mismatched `:cube` prop was silently ignored, causing the component to always have `currentCube = null`.
- **Effect**: The editor showed "No content selected" and all quick action buttons (Reset, Duplicate, Copy, Export) were disabled because `hasContent` was always `false`.
- **Fix**: Changed `:cube` to `:current-cube` in all three layout variants (desktop, tablet, mobile) in `App.vue` (lines 553, 667, 788).

## Details

The `UnifiedEditor` component (`src/components/UnifiedEditor.vue`) defines:
```typescript
export interface UnifiedEditorProps {
  currentCube?: SpectralCube | null  // Vue kebab-case: :current-cube
  ...
}
```

But `App.vue` was passing:
```vue
<UnifiedEditor :cube="currentCube" @update:cube="updateCube" />
```

The correct binding (matching `UnifiedEditorWindow.vue` line 26) is:
```vue
<UnifiedEditor :current-cube="currentCube" @update:cube="updateCube" />
```

## Test plan

- [x] TypeScript type checking passes (`vue-tsc --noEmit`)
- [x] ESLint passes
- [x] Prettier formatting passes
- [x] All 3585 tests pass (`vitest run`)
- [ ] Verify that UnifiedEditor now shows cube parameters in Spectral mode
- [ ] Verify quick action buttons (Reset, Duplicate, Randomize, Copy, Export) work
- [ ] Verify mode switching (Spectral, FFT, Stack) functions correctly

Fixes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)