### PR TITLE
test: characterize canonical cube domain contracts

### DIFF
--- a/src/test/cube-domain-characterization.test.ts
+++ b/src/test/cube-domain-characterization.test.ts
@@ -85,19 +85,40 @@ describe('canonical SpectralCube characterization', () => {
     }
 
     for (const type of noiseTypes) {
-      expect(validateCube({ id: `noise_${type}`, base: { color: [0.5, 0.5, 0.5] }, noise: { type } }).valid).toBe(true)
+      expect(
+        validateCube({ id: `noise_${type}`, base: { color: [0.5, 0.5, 0.5] }, noise: { type } })
+          .valid
+      ).toBe(true)
     }
 
     for (const material of materials) {
-      expect(validateCube({ id: `material_${material}`, base: { color: [0.5, 0.5, 0.5] }, physics: { material } }).valid).toBe(true)
+      expect(
+        validateCube({
+          id: `material_${material}`,
+          base: { color: [0.5, 0.5, 0.5] },
+          physics: { material },
+        }).valid
+      ).toBe(true)
     }
 
     for (const break_pattern of breakPatterns) {
-      expect(validateCube({ id: `break_${break_pattern}`, base: { color: [0.5, 0.5, 0.5] }, physics: { break_pattern } }).valid).toBe(true)
+      expect(
+        validateCube({
+          id: `break_${break_pattern}`,
+          base: { color: [0.5, 0.5, 0.5] },
+          physics: { break_pattern },
+        }).valid
+      ).toBe(true)
     }
 
     for (const mode of boundaryModes) {
-      expect(validateCube({ id: `boundary_${mode}`, base: { color: [0.5, 0.5, 0.5] }, boundary: { mode } }).valid).toBe(true)
+      expect(
+        validateCube({
+          id: `boundary_${mode}`,
+          base: { color: [0.5, 0.5, 0.5] },
+          boundary: { mode },
+        }).valid
+      ).toBe(true)
     }
   })
 
@@ -135,7 +156,10 @@ describe('canonical SpectralCube characterization', () => {
     const invalidCases: unknown[] = [
       { ...base, unexpected: true },
       { ...base, base: { ...base.base, unexpected: true } },
-      { ...base, gradients: [{ axis: 'x', factor: 0.5, color_shift: [0, 0, 0], unexpected: true }] },
+      {
+        ...base,
+        gradients: [{ axis: 'x', factor: 0.5, color_shift: [0, 0, 0], unexpected: true }],
+      },
       { ...base, noise: { type: 'perlin', unexpected: true } },
       { ...base, physics: { material: 'stone', unexpected: true } },
       { ...base, boundary: { mode: 'smooth', unexpected: true } },
@@ -178,7 +202,9 @@ describe('canonical SpectralCube characterization', () => {
     expect(cube.physics?.density).toBe(properties.physics.properties.density.default)
     expect(cube.physics?.break_pattern).toBe(properties.physics.properties.break_pattern.default)
     expect(cube.boundary?.mode).toBe(properties.boundary.properties.mode.default)
-    expect(cube.boundary?.neighbor_influence).toBe(properties.boundary.properties.neighbor_influence.default)
+    expect(cube.boundary?.neighbor_influence).toBe(
+      properties.boundary.properties.neighbor_influence.default
+    )
 
     expect(CUBE_DEFAULTS.base.roughness).toBe(properties.base.properties.roughness.default)
     expect(CUBE_DEFAULTS.base.transparency).toBe(properties.base.properties.transparency.default)

--- a/src/test/cube-domain-characterization.test.ts
+++ b/src/test/cube-domain-characterization.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+import { validateAndParseCube, validateCube } from '../lib/validation'
+import cubeSchema from '../types/cube-schema.json'
+import {
+  CUBE_DEFAULTS,
+  createDefaultCube,
+  type BreakPattern,
+  type BoundaryMode,
+  type GradientAxis,
+  type MaterialType,
+  type NoiseType,
+  type SpectralCube,
+} from '../types/cube'
+
+const cloneThroughJson = (cube: SpectralCube): unknown => JSON.parse(JSON.stringify(cube))
+
+describe('canonical SpectralCube characterization', () => {
+  it('round-trips a fully populated typed cube through JSON and runtime validation', () => {
+    const cube = {
+      id: 'round_trip_cube',
+      prompt: 'characterization fixture',
+      base: {
+        color: [0, 0.5, 1],
+        roughness: 0,
+        transparency: 1,
+      },
+      gradients: [
+        { axis: 'x', factor: 0, color_shift: [-1, 0, 1] },
+        { axis: 'radial', factor: 1, color_shift: [1, -1, 0] },
+      ],
+      noise: {
+        type: 'worley',
+        scale: 0.1,
+        octaves: 8,
+        persistence: 1,
+        mask: 'edges_20%',
+      },
+      physics: {
+        material: 'crystal',
+        density: 20,
+        break_pattern: 'shatter',
+      },
+      boundary: {
+        mode: 'hard',
+        neighbor_influence: 1,
+      },
+      meta: {
+        name: 'Round-trip fixture',
+        tags: ['contract', 'cube'],
+        author: 'test',
+        created: '2026-01-02T03:04:05.000Z',
+        modified: '2026-01-03T03:04:05.000Z',
+      },
+    } satisfies SpectralCube
+
+    const parsed = validateAndParseCube(cloneThroughJson(cube))
+
+    expect(parsed).toEqual(cube)
+    expect(JSON.parse(JSON.stringify(parsed))).toEqual(cube)
+  })
+
+  it('keeps TypeScript enum members accepted by the JSON schema', () => {
+    const axes: GradientAxis[] = ['x', 'y', 'z', 'radial']
+    const noiseTypes: NoiseType[] = ['perlin', 'worley', 'crackle']
+    const materials: MaterialType[] = [
+      'stone',
+      'wood',
+      'metal',
+      'glass',
+      'organic',
+      'crystal',
+      'liquid',
+    ]
+    const breakPatterns: BreakPattern[] = ['crumble', 'shatter', 'splinter', 'melt', 'dissolve']
+    const boundaryModes: BoundaryMode[] = ['none', 'smooth', 'hard']
+
+    for (const axis of axes) {
+      expect(
+        validateCube({
+          id: `axis_${axis}`,
+          base: { color: [0.5, 0.5, 0.5] },
+          gradients: [{ axis, factor: 0.5, color_shift: [0, 0, 0] }],
+        }).valid
+      ).toBe(true)
+    }
+
+    for (const type of noiseTypes) {
+      expect(validateCube({ id: `noise_${type}`, base: { color: [0.5, 0.5, 0.5] }, noise: { type } }).valid).toBe(true)
+    }
+
+    for (const material of materials) {
+      expect(validateCube({ id: `material_${material}`, base: { color: [0.5, 0.5, 0.5] }, physics: { material } }).valid).toBe(true)
+    }
+
+    for (const break_pattern of breakPatterns) {
+      expect(validateCube({ id: `break_${break_pattern}`, base: { color: [0.5, 0.5, 0.5] }, physics: { break_pattern } }).valid).toBe(true)
+    }
+
+    for (const mode of boundaryModes) {
+      expect(validateCube({ id: `boundary_${mode}`, base: { color: [0.5, 0.5, 0.5] }, boundary: { mode } }).valid).toBe(true)
+    }
+  })
+
+  it('accepts documented numeric boundaries and rejects values immediately outside them', () => {
+    const validBoundaryCube = {
+      id: 'numeric_boundaries',
+      base: { color: [0, 1, 0.5], roughness: 0, transparency: 1 },
+      gradients: [{ axis: 'z', factor: 1, color_shift: [-1, 1, 0] }],
+      noise: { scale: 100, octaves: 1, persistence: 0 },
+      physics: { density: 0.01 },
+      boundary: { neighbor_influence: 0 },
+    } satisfies SpectralCube
+
+    expect(validateCube(validBoundaryCube).valid).toBe(true)
+
+    const invalidCases: unknown[] = [
+      { ...validBoundaryCube, base: { ...validBoundaryCube.base, color: [-0.0001, 1, 0.5] } },
+      { ...validBoundaryCube, base: { ...validBoundaryCube.base, roughness: 1.0001 } },
+      { ...validBoundaryCube, base: { ...validBoundaryCube.base, transparency: -0.0001 } },
+      { ...validBoundaryCube, gradients: [{ axis: 'z', factor: 1.0001, color_shift: [-1, 1, 0] }] },
+      { ...validBoundaryCube, gradients: [{ axis: 'z', factor: 1, color_shift: [-1.0001, 1, 0] }] },
+      { ...validBoundaryCube, noise: { scale: 0.0999 } },
+      { ...validBoundaryCube, noise: { octaves: 9 } },
+      { ...validBoundaryCube, physics: { density: 20.0001 } },
+      { ...validBoundaryCube, boundary: { neighbor_influence: 1.0001 } },
+    ]
+
+    for (const invalid of invalidCases) {
+      expect(validateCube(invalid).valid).toBe(false)
+    }
+  })
+
+  it('rejects unknown fields at every persisted object boundary', () => {
+    const base = { id: 'unknown_fields', base: { color: [0.5, 0.5, 0.5] } }
+    const invalidCases: unknown[] = [
+      { ...base, unexpected: true },
+      { ...base, base: { ...base.base, unexpected: true } },
+      { ...base, gradients: [{ axis: 'x', factor: 0.5, color_shift: [0, 0, 0], unexpected: true }] },
+      { ...base, noise: { type: 'perlin', unexpected: true } },
+      { ...base, physics: { material: 'stone', unexpected: true } },
+      { ...base, boundary: { mode: 'smooth', unexpected: true } },
+      { ...base, meta: { name: 'fixture', unexpected: true } },
+    ]
+
+    for (const invalid of invalidCases) {
+      const result = validateCube(invalid)
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((error) => error.keyword === 'additionalProperties')).toBe(true)
+    }
+  })
+
+  it('rejects malformed required fields, invalid ids and invalid timestamps', () => {
+    const invalidCases: unknown[] = [
+      {},
+      { id: 'missing_base' },
+      { id: 'UPPERCASE', base: { color: [0.5, 0.5, 0.5] } },
+      { id: 'bad-color', base: { color: [0.5, 0.5] } },
+      { id: 'bad_color_value', base: { color: [0.5, 0.5, 2] } },
+      { id: 'bad_date', base: { color: [0.5, 0.5, 0.5] }, meta: { created: 'not-a-date' } },
+    ]
+
+    for (const invalid of invalidCases) {
+      expect(validateCube(invalid).valid).toBe(false)
+    }
+  })
+
+  it('keeps constructor defaults synchronized with schema defaults', () => {
+    const cube = createDefaultCube('default_parity')
+    const properties = cubeSchema.properties
+
+    expect(cube.base.roughness).toBe(properties.base.properties.roughness.default)
+    expect(cube.base.transparency).toBe(properties.base.properties.transparency.default)
+    expect(cube.noise?.type).toBe(properties.noise.properties.type.default)
+    expect(cube.noise?.scale).toBe(properties.noise.properties.scale.default)
+    expect(cube.noise?.octaves).toBe(properties.noise.properties.octaves.default)
+    expect(cube.noise?.persistence).toBe(properties.noise.properties.persistence.default)
+    expect(cube.physics?.material).toBe(properties.physics.properties.material.default)
+    expect(cube.physics?.density).toBe(properties.physics.properties.density.default)
+    expect(cube.physics?.break_pattern).toBe(properties.physics.properties.break_pattern.default)
+    expect(cube.boundary?.mode).toBe(properties.boundary.properties.mode.default)
+    expect(cube.boundary?.neighbor_influence).toBe(properties.boundary.properties.neighbor_influence.default)
+
+    expect(CUBE_DEFAULTS.base.roughness).toBe(properties.base.properties.roughness.default)
+    expect(CUBE_DEFAULTS.base.transparency).toBe(properties.base.properties.transparency.default)
+  })
+})

--- a/src/test/example-cube-contracts.test.ts
+++ b/src/test/example-cube-contracts.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import brickRed from '../../examples/brick-red.json'
+import crystalMagic from '../../examples/crystal-magic.json'
+import energyShield from '../../examples/energy-shield.json'
+import grassGreen from '../../examples/grass-green.json'
+import iceFrozen from '../../examples/ice-frozen.json'
+import lavaMolten from '../../examples/lava-molten.json'
+import magicCrystalEnergy from '../../examples/magic-crystal-energy.json'
+import marbleWhite from '../../examples/marble-white.json'
+import metalRust from '../../examples/metal-rust.json'
+import sandDesert from '../../examples/sand-desert.json'
+import stoneMoss from '../../examples/stone-moss.json'
+import unstableCore from '../../examples/unstable-core.json'
+import woodOak from '../../examples/wood-oak.json'
+import { validateAndParseCube, validateCube } from '../lib/validation'
+
+const shippedPresets: Array<[string, unknown]> = [
+  ['brick-red.json', brickRed],
+  ['crystal-magic.json', crystalMagic],
+  ['energy-shield.json', energyShield],
+  ['grass-green.json', grassGreen],
+  ['ice-frozen.json', iceFrozen],
+  ['lava-molten.json', lavaMolten],
+  ['magic-crystal-energy.json', magicCrystalEnergy],
+  ['marble-white.json', marbleWhite],
+  ['metal-rust.json', metalRust],
+  ['sand-desert.json', sandDesert],
+  ['stone-moss.json', stoneMoss],
+  ['unstable-core.json', unstableCore],
+  ['wood-oak.json', woodOak],
+]
+
+describe('shipped cube preset contracts', () => {
+  it.each(shippedPresets)('%s is schema-valid', (_filename, preset) => {
+    expect(validateCube(preset)).toEqual({ valid: true, errors: [] })
+  })
+
+  it.each(shippedPresets)('%s survives the canonical JSON round trip', (_filename, preset) => {
+    const serialized = JSON.stringify(preset)
+    const reparsed: unknown = JSON.parse(serialized)
+    const cube = validateAndParseCube(reparsed)
+
+    expect(cube).toEqual(preset)
+    expect(JSON.parse(JSON.stringify(cube))).toEqual(preset)
+  })
+})

--- a/src/test/metamode.json
+++ b/src/test/metamode.json
@@ -11,6 +11,9 @@
     },
     "cube-domain-characterization.test.ts": {
       "description": "SpectralCube schema parity, numeric boundary, malformed input, unknown field and JSON round-trip characterization contracts"
+    },
+    "example-cube-contracts.test.ts": {
+      "description": "Schema validation and canonical JSON round-trip contracts for every shipped cube preset in examples/"
     }
   }
 }

--- a/src/test/metamode.json
+++ b/src/test/metamode.json
@@ -8,6 +8,9 @@
     },
     "core-contracts.test.ts": {
       "description": "Core cube characterization contracts for schema validity, deterministic defaults and independent mutable state"
+    },
+    "cube-domain-characterization.test.ts": {
+      "description": "SpectralCube schema parity, numeric boundary, malformed input, unknown field and JSON round-trip characterization contracts"
     }
   }
 }


### PR DESCRIPTION
Part of #301. Depends on completed #300.

## Scope

Test-only first step for Phase 15.2. No production behavior changes.

Adds characterization contracts for the currently persisted `SpectralCube` boundary before introducing versioning, migrations or splitting AI/FFT types:

- JSON serialize/parse/runtime-validation round trip for a fully populated typed cube;
- TypeScript enum members accepted by the JSON schema;
- documented numeric boundary acceptance and immediately-outside rejection;
- unknown-property rejection at root and nested persisted object boundaries;
- malformed required fields, IDs, colors and timestamps;
- constructor/default constants kept equal to JSON Schema defaults;
- **all 13 shipped `examples/*.json` presets** must validate and survive canonical JSON round-trip.

The new tests are registered in MetaMode metadata.

## Inventory findings for the next #301 step

- `src/types/cube.ts` mixes persisted SpectralCube/FFT primitives with AI generation types;
- the persisted SpectralCube JSON Schema has no explicit format version;
- `validateAndParseCube()` validates then casts but has no normalize/migration entrypoint;
- file import and current-cube loading validate schema, while saved-config loading currently parses/casts storage records directly;
- Gallery imports 13 shipped preset JSON files and casts them to `SpectralCube`.

## Why this PR comes first

#301 requires characterization before structural refactoring. These tests freeze current observable storage/schema behavior so later production changes must preserve or explicitly migrate it.

## Next after green

Add explicit version/migration contracts around the canonical parse boundary, then route persistence/import consumers through it before splitting types.

## Merge gate

Full strict CI from #311 must be green on all mandatory jobs. Tests will not be weakened to make the branch pass.