### PR TITLE
feat: introduce canonical cube format v1 migration boundary

### DIFF
--- a/src/domain/cube-format.ts
+++ b/src/domain/cube-format.ts
@@ -1,0 +1,55 @@
+import { validateAndParseCube } from '../lib/validation'
+import type { SpectralCube } from '../types/cube'
+
+export const CURRENT_CUBE_FORMAT_VERSION = 1 as const
+
+export type CubeFormatVersion = typeof CURRENT_CUBE_FORMAT_VERSION
+
+export type CanonicalSpectralCube = SpectralCube & {
+  format_version: CubeFormatVersion
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function describeVersion(version: unknown): string {
+  return typeof version === 'string' ? JSON.stringify(version) : String(version)
+}
+
+export function migrateCubeDocument(input: unknown): unknown {
+  if (!isRecord(input)) {
+    return input
+  }
+
+  const version = input.format_version
+
+  if (version === undefined) {
+    return {
+      ...input,
+      format_version: CURRENT_CUBE_FORMAT_VERSION,
+    }
+  }
+
+  if (version !== CURRENT_CUBE_FORMAT_VERSION) {
+    throw new Error(`Unsupported cube format version: ${describeVersion(version)}`)
+  }
+
+  return input
+}
+
+export function parseCubeDocument(input: unknown): CanonicalSpectralCube {
+  const migrated = migrateCubeDocument(input)
+  const cube = validateAndParseCube(migrated)
+
+  if (cube.format_version !== CURRENT_CUBE_FORMAT_VERSION) {
+    throw new Error('Cube migration did not produce the current canonical format')
+  }
+
+  return cube as CanonicalSpectralCube
+}
+
+export function serializeCubeDocument(cube: CanonicalSpectralCube): string {
+  const validated = parseCubeDocument(cube)
+  return JSON.stringify(validated)
+}

--- a/src/domain/cube-format.ts
+++ b/src/domain/cube-format.ts
@@ -41,12 +41,13 @@ export function migrateCubeDocument(input: unknown): unknown {
 export function parseCubeDocument(input: unknown): CanonicalSpectralCube {
   const migrated = migrateCubeDocument(input)
   const cube = validateAndParseCube(migrated)
+  const versionedCube = cube as SpectralCube & { format_version?: unknown }
 
-  if (cube.format_version !== CURRENT_CUBE_FORMAT_VERSION) {
+  if (versionedCube.format_version !== CURRENT_CUBE_FORMAT_VERSION) {
     throw new Error('Cube migration did not produce the current canonical format')
   }
 
-  return cube as CanonicalSpectralCube
+  return versionedCube as CanonicalSpectralCube
 }
 
 export function serializeCubeDocument(cube: CanonicalSpectralCube): string {

--- a/src/domain/metamode.json
+++ b/src/domain/metamode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../metamode.schema.json",
+  "name": "domain",
+  "description": "Framework-agnostic canonical domain boundaries for persisted isocubic data",
+  "files": {
+    "cube-format.ts": {
+      "description": "Canonical SpectralCube format version, legacy migration, validation parse boundary and serialization"
+    }
+  }
+}

--- a/src/lib/metamode-cli.test.ts
+++ b/src/lib/metamode-cli.test.ts
@@ -140,7 +140,7 @@ describe('MetaMode CLI Integration (TASK 86)', () => {
 
     it('should find metamode.json files in the project', () => {
       const report = analyzeMigration(PROJECT_ROOT)
-      // isocubic has 32 metamode.json files
+      // isocubic has 33 metamode.json files
       expect(report.totalFiles).toBeGreaterThan(0)
     })
 
@@ -409,7 +409,7 @@ describe('MetaMode CLI Integration (TASK 86)', () => {
 
       expect(report.mode).toBe('dry-run')
       expect(report.errors).toHaveLength(0) // No parse errors expected
-      expect(report.totalFiles).toBe(32) // isocubic has 32 metamode.json files
+      expect(report.totalFiles).toBe(33) // isocubic has 33 metamode.json files
       expect(report.totalAnnotations).toBeGreaterThan(100) // Many file annotations
     })
 

--- a/src/metamode.json
+++ b/src/metamode.json
@@ -32,6 +32,10 @@
       "description": "Vue composables for reusable reactive logic",
       "metamode": "composables/metamode.json"
     },
+    "domain": {
+      "description": "Framework-agnostic canonical persisted-data domain boundaries",
+      "metamode": "domain/metamode.json"
+    },
     "lib": {
       "description": "TypeScript library modules (core logic, utilities, AI)",
       "metamode": "lib/metamode.json"

--- a/src/test/cube-format-versioning.test.ts
+++ b/src/test/cube-format-versioning.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CURRENT_CUBE_FORMAT_VERSION,
+  migrateCubeDocument,
+  parseCubeDocument,
+  serializeCubeDocument,
+} from '../domain/cube-format'
+import { validateCube } from '../lib/validation'
+
+const legacyCube = {
+  id: 'legacy_cube',
+  base: {
+    color: [0.25, 0.5, 0.75],
+    roughness: 0.4,
+    transparency: 1,
+  },
+  boundary: {
+    mode: 'smooth',
+    neighbor_influence: 0.5,
+  },
+  meta: {
+    name: 'Legacy cube',
+    created: '2026-01-02T03:04:05.000Z',
+  },
+}
+
+describe('cube format versioning contracts', () => {
+  it('defines version 1 as the current canonical cube format', () => {
+    expect(CURRENT_CUBE_FORMAT_VERSION).toBe(1)
+  })
+
+  it('migrates an unversioned legacy cube to canonical v1 without mutating the input', () => {
+    const original = JSON.parse(JSON.stringify(legacyCube))
+
+    const migrated = migrateCubeDocument(legacyCube)
+
+    expect(migrated).toEqual({
+      ...legacyCube,
+      format_version: CURRENT_CUBE_FORMAT_VERSION,
+    })
+    expect(legacyCube).toEqual(original)
+    expect(validateCube(migrated)).toEqual({ valid: true, errors: [] })
+  })
+
+  it('accepts an already-current document without changing its semantic data', () => {
+    const current = {
+      ...legacyCube,
+      format_version: CURRENT_CUBE_FORMAT_VERSION,
+    }
+
+    expect(parseCubeDocument(current)).toEqual(current)
+  })
+
+  it('normalizes legacy input before parse returns a canonical document', () => {
+    const parsed = parseCubeDocument(legacyCube)
+
+    expect(parsed.format_version).toBe(CURRENT_CUBE_FORMAT_VERSION)
+    expect(parsed.id).toBe(legacyCube.id)
+    expect(parsed.base).toEqual(legacyCube.base)
+  })
+
+  it('rejects unsupported future format versions instead of silently coercing them', () => {
+    expect(() =>
+      parseCubeDocument({
+        ...legacyCube,
+        format_version: CURRENT_CUBE_FORMAT_VERSION + 1,
+      })
+    ).toThrow('Unsupported cube format version: 2')
+  })
+
+  it('rejects malformed legacy input after migration instead of blessing it as canonical', () => {
+    expect(() =>
+      parseCubeDocument({
+        id: 'malformed_cube',
+        base: { color: [2, 0.5, 0.5] },
+      })
+    ).toThrow('Invalid SpectralCube configuration')
+  })
+
+  it('serializes canonical v1 deterministically enough for semantic parse round trips', () => {
+    const canonical = parseCubeDocument(legacyCube)
+    const serialized = serializeCubeDocument(canonical)
+    const reparsed = parseCubeDocument(JSON.parse(serialized))
+
+    expect(reparsed).toEqual(canonical)
+    expect(JSON.parse(serialized)).toEqual(canonical)
+  })
+})

--- a/src/test/metamode.json
+++ b/src/test/metamode.json
@@ -14,6 +14,9 @@
     },
     "example-cube-contracts.test.ts": {
       "description": "Schema validation and canonical JSON round-trip contracts for every shipped cube preset in examples/"
+    },
+    "cube-format-versioning.test.ts": {
+      "description": "Test-first contracts for explicit cube format versioning, legacy migration, rejection of unsupported versions and canonical serialization"
     }
   }
 }

--- a/src/types/cube-schema.json
+++ b/src/types/cube-schema.json
@@ -11,6 +11,11 @@
       "pattern": "^[a-z0-9_]+$",
       "examples": ["stone_moss_001", "wood_oak_002", "metal_rust_003"]
     },
+    "format_version": {
+      "type": "integer",
+      "description": "Explicit persisted cube format version. Legacy unversioned documents are migrated before canonical use.",
+      "const": 1
+    },
     "prompt": {
       "type": "string",
       "description": "Text prompt used to generate this cube configuration",


### PR DESCRIPTION
Part of #301. Follows merged characterization PR #313.

## Test-first order

The branch commits the version/migration contracts before the production implementation.

## Contracts

- current canonical format is explicitly version `1`;
- unversioned legacy `SpectralCube` input migrates to v1 without mutating the input;
- already-current v1 documents preserve semantic data;
- unsupported future versions fail explicitly instead of being silently coerced;
- malformed legacy documents remain invalid after migration;
- canonical serialize → parse is a semantic round trip;
- migrated canonical documents remain valid against the JSON Schema.

## Production boundary

Adds framework-agnostic `src/domain/cube-format.ts` with:

- `CURRENT_CUBE_FORMAT_VERSION`;
- `CanonicalSpectralCube`;
- `migrateCubeDocument()`;
- `parseCubeDocument()`;
- `serializeCubeDocument()`.

The JSON Schema now declares optional `format_version` constrained to `1`. Legacy unversioned examples remain accepted by the existing validator; canonical parsing upgrades them to explicit v1. The legacy `SpectralCube` TypeScript interface is intentionally not mass-changed yet, so consumer migration can be staged and tested rather than hidden behind casts.

## Scope boundary

This PR does not yet reroute LocalStorage/file/editor consumers. That comes after this boundary is green, with storage/import characterization tests first.

## Merge gate

All strict CI jobs must be green. No test/schema weakening to force merge.